### PR TITLE
#165668030 Implement admin update type of user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7037,6 +7037,14 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
+    "valid_me_js": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid_me_js/-/valid_me_js-1.0.9.tgz",
+      "integrity": "sha512-Xv6QZe33/ZIXkMZ4ElAbErWUs7zAGSLBKlXjOxcT5P/viBGwOKRlyADK2g1GthW7fZVpTah0xoHEPJLj7apTSw==",
+      "requires": {
+        "validator": "^10.9.0"
+      }
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -7046,6 +7054,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.11",
     "morgan": "^1.9.1",
-    "pg": "^7.10.0"
+    "pg": "^7.10.0",
+    "valid_me_js": "^1.0.9"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.3",

--- a/server/middleware/BodySchemaValidator.js
+++ b/server/middleware/BodySchemaValidator.js
@@ -1,0 +1,42 @@
+import Joi from 'joi';
+import Schemas from './validatorSchema/bodySchemas';
+
+export default () => {
+  // enabled HTTP methods for request data validation
+  const supportedMethods = ['post', 'put', 'patch'];
+
+  // Joi validation options
+  const validationOptions = { abortEarly: false, allowUnknown: true, stripUnknown: true };
+
+  // return the validation middleware
+  return (req, res, next) => {
+    const route = req.route.path;
+    const method = req.method.toLowerCase();
+
+    if (supportedMethods.includes(method) && route in Schemas) {
+    // get schema for the current route
+      const schema = Schemas[route];
+
+      if (schema) {
+      // Validate req.body using the schema and validation options
+        return Joi.validate(req.body, schema, validationOptions, (err, data) => {
+          if (err) {
+          // Custom Error
+            const SimplifiedError = {
+              status: 400,
+              error: err.details ? err.details[0].message.replace(/['"]/g, '') : err.message,
+            };
+
+            // Send back the JSON error response
+            res.status(400).json(SimplifiedError);
+          } else {
+          // Replace req.body with the data after Joi validation
+            req.body = data;
+            return next();
+          }
+        });
+      }
+    }
+    return next();
+  };
+};

--- a/server/middleware/ParamsSchemaValidator.js
+++ b/server/middleware/ParamsSchemaValidator.js
@@ -1,0 +1,43 @@
+import Joi from 'joi';
+import Schemas from './validatorSchema/paramsSchemas';
+
+export default () => {
+  // enabled HTTP methods for request data validation
+  const supportedMethods = ['get', 'post', 'patch', 'delete'];
+
+  // Joi validation options
+  const validationOptions = { abortEarly: false, allowUnknown: true, stripUnknown: true };
+
+  // return the validation middleware
+  return (req, res, next) => {
+    const route = req.route.path;
+    const method = req.method.toLowerCase();
+
+    if (supportedMethods.includes(method) && route in Schemas) {
+    // get schema for the current route
+      const schema = Schemas[route];
+
+
+      if (schema) {
+      // Validate req.body using the schema and validation options
+        return Joi.validate(req.params, schema, validationOptions, (err, data) => {
+          if (err) {
+          // Custom Error
+            const SimplifiedError = {
+              status: 400,
+              error: err.details ? err.details[0].message.replace(/['"]/g, '') : err.message,
+            };
+
+            // Send back the JSON error response
+            res.status(400).json(SimplifiedError);
+          } else {
+          // Replace req.params with the data after Joi validation
+            req.params = data;
+            return next();
+          }
+        });
+      }
+    }
+    return next();
+  };
+};

--- a/server/middleware/validate.js
+++ b/server/middleware/validate.js
@@ -9,7 +9,22 @@ const validate = {
       password: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required(),
       confirmPassword: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required()
     });
-    const { value, error } = Joi.validate(body, schema);
+    const { value, error } = Joi.validate(body, params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  signupParams(params) {
+    const schema = Joi.object().keys({
+      email: Joi.string().email({ minDomainAtoms: 2 }).required(),
+      firstName: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required(),
+      lastName: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required(),
+      password: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required(),
+      confirmPassword: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required()
+    });
+    const { value, error } = Joi.validate(params, schema);
     if (error && error.details) {
       return { error };
     }
@@ -28,6 +43,19 @@ const validate = {
     return { value };
   },
 
+
+  signinParams(params) {
+    const schema = Joi.object().keys({
+      email: Joi.string().email({ minDomainAtoms: 2 }).required(),
+      password: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required()
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
   createAccount(body) {
     const schema = Joi.object().keys({
       type: Joi.string().valid('savings', 'current').required(),
@@ -39,11 +67,33 @@ const validate = {
     return { value };
   },
 
+  createAccountParams(params) {
+    const schema = Joi.object().keys({
+      type: Joi.string().valid('savings', 'current').required(),
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
   patchAccount(body) {
     const schema = Joi.object().keys({
       status: Joi.string().valid('active', 'dormant').required(),
     });
     const { value, error } = Joi.validate(body, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  patchAccountParams(params) {
+    const schema = Joi.object().keys({
+      status: Joi.string().valid('active', 'dormant').required(),
+    });
+    const { value, error } = Joi.validate(params, schema);
     if (error && error.details) {
       return { error };
     }
@@ -62,6 +112,18 @@ const validate = {
     return { value };
   },
 
+  creditAccountParams(params) {
+    const schema = Joi.object().keys({
+      amount: Joi.number().precision(2).required(),
+      cashier: Joi.number().integer().positive().required(),
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
   debitAccount(body) {
     const schema = Joi.object().keys({
       amount: Joi.number().precision(2).required(),
@@ -74,6 +136,49 @@ const validate = {
     return { value };
   },
 
+  accountNumber(body) {
+    const schema = Joi.object().keys({
+      type: Joi.number().positive().integer().required(),
+    });
+    const { value, error } = Joi.validate(body, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  email(body) {
+    const schema = Joi.object().keys({
+      email: Joi.string().email({ minDomainAtoms: 2 }).required(),
+    });
+    const { value, error } = Joi.validate(body, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  emailParams(params) {
+    const schema = Joi.object().keys({
+      email: Joi.string().email({ minDomainAtoms: 2 }).required(),
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  makecashier(body) {
+    const schema = Joi.object().keys({
+      email: Joi.string().email({ minDomainAtoms: 2 }).required(),
+    });
+    const { value, error } = Joi.validate(body, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
 };
 
 export default validate;

--- a/server/middleware/validateParams.js
+++ b/server/middleware/validateParams.js
@@ -1,0 +1,102 @@
+import Joi from 'joi';
+
+
+const validateParams = {
+  signup(params) {
+    const schema = Joi.object().keys({
+      email: Joi.string().email({ minDomainAtoms: 2 }).required(),
+      firstName: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required(),
+      lastName: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required(),
+      password: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required(),
+      confirmPassword: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required()
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  signin(params) {
+    const schema = Joi.object().keys({
+      email: Joi.string().email({ minDomainAtoms: 2 }).required(),
+      password: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/).required()
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  createAccount(params) {
+    const schema = Joi.object().keys({
+      type: Joi.string().valid('savings', 'current').required(),
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  accountNumber(params) {
+    const schema = Joi.object().keys({
+      type: Joi.number().positive().integer().required(),
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  email(params) {
+    const schema = Joi.object().keys({
+      email: Joi.string().email({ minDomainAtoms: 2 }).required(),
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  patchAccount(params) {
+    const schema = Joi.object().keys({
+      status: Joi.string().valid('active', 'dormant').required(),
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  creditAccount(params) {
+    const schema = Joi.object().keys({
+      amount: Joi.number().precision(2).required(),
+      cashier: Joi.number().integer().positive().required(),
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+  debitAccount(params) {
+    const schema = Joi.object().keys({
+      amount: Joi.number().precision(2).required(),
+      cashier: Joi.number().integer().positive().required(),
+    });
+    const { value, error } = Joi.validate(params, schema);
+    if (error && error.details) {
+      return { error };
+    }
+    return { value };
+  },
+
+};
+
+export default validateParams;

--- a/server/middleware/validator.js
+++ b/server/middleware/validator.js
@@ -1,0 +1,11 @@
+import { customMiddleware } from 'valid_me_js';
+
+const accountNumberValidate = (req, res, next) => {
+  const valid = customMiddleware(req, res, next);
+
+  valid
+    .hasElement('accountNumber')
+    .check();
+};
+
+export default { accountNumberValidate };

--- a/server/middleware/validatorSchema/bodySchemas.js
+++ b/server/middleware/validatorSchema/bodySchemas.js
@@ -1,0 +1,55 @@
+import Joi from 'joi';
+
+const name = Joi.string().regex(/^\D+$/).required();
+
+const email = Joi.string().email().lowercase()
+  .required();
+
+const password = Joi.string().min(7).required().strict();
+
+const createUserSchema = Joi.object({
+  firstName: name,
+  lastName: name,
+  email,
+  password,
+  confirmPassword: Joi.string().valid(Joi.ref('password')).required().strict()
+    .error(new Error('your password and confirm password do not match')),
+});
+
+const createStaffSchema = Joi.object({
+  firstName: name,
+  lastName: name,
+  email,
+  password,
+  isAdmin: Joi.boolean().required(),
+});
+
+const loginUserSchema = Joi.object({
+  email,
+  password,
+});
+
+const createAccountSchema = Joi.object({
+  type: Joi.string().lowercase().valid('savings', 'current').required(),
+  balance: Joi.number().positive().allow(0).precision(2)
+    .default(0.00),
+});
+
+const updateStatusSchema = Joi.object({
+  status: Joi.string().lowercase().valid('dormant', 'active').required(),
+});
+
+const transactionSchema = Joi.object({
+  amount: Joi.number().positive().precision(2).required(),
+});
+
+
+export default {
+  '/signup': createUserSchema,
+  '/signin': loginUserSchema,
+  '/accounts': createAccountSchema,
+  '/accounts/:accountNumber': updateStatusSchema,
+  '/transactions/:accountNumber/debit': transactionSchema,
+  '/transactions/:accountNumber/credit': transactionSchema,
+  '/create/staff': createStaffSchema,
+};

--- a/server/middleware/validatorSchema/paramsSchemas.js
+++ b/server/middleware/validatorSchema/paramsSchemas.js
@@ -1,0 +1,27 @@
+import Joi from 'joi';
+
+const accountNumber = Joi.string().regex(/^\d+$/).required();
+
+const accountNumberSchema = Joi.object({
+  accountNumber: accountNumber.error(new Error('accountNumber must be an integer')),
+});
+
+const transactionIdSchema = Joi.object({
+  transactionId: accountNumber.error(new Error('trasactionId must be an integer')),
+});
+
+const emailSchema = Joi.object({
+  email: Joi.string()
+    .email({ minDomainAtoms: 2 })
+    .lowercase()
+    .required(),
+});
+
+export default {
+  '/accounts/:accountNumber': accountNumberSchema,
+  '/transactions/:accountNumber/credit': accountNumberSchema,
+  '/transactions/:accountNumber/debit': accountNumberSchema,
+  '/accounts/:accountNumber/transactions': accountNumberSchema,
+  '/transactions/:transactionId': transactionIdSchema,
+  '/user/:email/accounts': emailSchema,
+};

--- a/server/middleware/validatorSchema/querySchemas.js
+++ b/server/middleware/validatorSchema/querySchemas.js
@@ -1,0 +1,9 @@
+import Joi from 'joi';
+
+const statusSchema = Joi.object({
+  status: Joi.string().lowercase().valid('dormant', 'active'),
+});
+
+export default {
+  '/accounts?status=dormant': statusSchema,
+};

--- a/server/test/user.spec.js
+++ b/server/test/user.spec.js
@@ -1,4 +1,4 @@
-import chai from 'chai';
+import chai, { expect } from 'chai';
 import 'chai/register-should';
 import chaiHttp from 'chai-http';
 
@@ -31,7 +31,10 @@ describe('Test user login and signup', () => {
         .post('/api/v2/auth/signup')
         .send(newUser)
         .end((err, response) => {
-          response.should.have.status(409);
+          expect(response.statusCode).to.be.equal(201);
+          expect(response.body).to.have.property('status').to.eql(201);
+          expect(response.body).to.have.property('message');
+          expect(response.body).to.have.property('error');
           response.body.should.be.a('object');
           done();
         });

--- a/server/v2/controllers/account.js
+++ b/server/v2/controllers/account.js
@@ -1,5 +1,5 @@
 import jwt from 'jsonwebtoken';
-import validate from '../../middleware/validate';
+import validateBody from '../../middleware/validate';
 import connectDB from '../../connectDB';
 
 class accountController {
@@ -9,7 +9,7 @@ class accountController {
       id, firstName, lastName, email
     } = data;
 
-    const { value, error } = validate.createAccount(request.body);
+    const { value, error } = validateBody.createAccount(request.body);
     if (error) {
       return response.status(400).json({
         status: 400,
@@ -119,7 +119,7 @@ class accountController {
     const { accountNumber } = request.params;
     const { status } = request.body;
 
-    const { value, error } = validate.patchAccount(request.body, request.params);
+    const { value, error } = validateBody.patchAccount(request.body, request.params);
     if (error) {
       return response.status(400).json({
         status: 422,

--- a/server/v2/controllers/transaction.js
+++ b/server/v2/controllers/transaction.js
@@ -47,10 +47,16 @@ class TransactionController {
     const data = jwt.verify(request.token, process.env.jwt_secret);
     const { id } = data;
 
+    const { valueAccountNumber, errorAccountNumber } = validate.accountNumberParams(request.params);
+    if (errorAccountNumber) {
+      return response.status(400).json({ status: 400, error: 'Invalid input' });
+    }
+
     const { value, error } = validate.creditAccount(request.body);
     if (error) {
       return response.status(400).json({ status: 400, error: error.details[0].message });
     }
+
 
     const findSpecificAccount = `SELECT * FROM accounts WHERE "accountNumber"='${(accountNumber)}'`;
     return connectDB.query(findSpecificAccount)

--- a/server/v2/controllers/user.js
+++ b/server/v2/controllers/user.js
@@ -16,7 +16,7 @@ class userController {
     if (error) {
       return response.status(400).json({
         status: 400,
-        error: error.details[0].message
+        error: 'Invalid input, ensure input values are/is correct'
       });
     }
 
@@ -69,7 +69,7 @@ class userController {
     if (error) {
       return response.status(400).json({
         status: 400,
-        error: error.details[0].message
+        error: 'Invalid input, ensure input values are/is correct'
       });
     }
 
@@ -90,6 +90,134 @@ class userController {
       })
       .catch((error) => {
         response.status(500).send({ status: 500, error: 'Error logging in, ensure you provide valid credentials' });
+      });
+  }
+
+  static getAllUsers(request, response) {
+    const query = 'SELECT * FROM users';
+    return connectDB.query(query)
+      .then((result) => {
+        if (result.rowCount === 0) {
+          response.status(400).send({
+            status:
+            400,
+            error: 'There are no user records'
+          });
+        }
+        return response.status(200).send({
+          status: 200,
+          message: 'Users successfully retrieved',
+          data: result.rows
+        });
+      })
+      .catch((error) => {
+        response.status(500).send({
+          status: 500,
+          error: 'Error fetching all users, ensure you provide valid credentials'
+        });
+      });
+  }
+
+  static getOneUser(request, response) {
+    const { email } = request.params;
+    const { value, error } = validate.emailParams(request.params);
+    if (error) {
+      return response.status(400).json({
+        status: 400,
+        error: 'Invalid input, ensure input values are/is correct'
+      });
+    }
+    const query = `SELECT * FROM users WHERE "email"='${email}'`;
+    return connectDB.query(query)
+      .then((result) => {
+        if (result.rowCount === 0) {
+          response.status(400).send({
+            status: 400,
+            error: 'User does not exist'
+          });
+        }
+        return response.status(200).send({
+          status: 200,
+          message: 'Account successfully retrieved',
+          data: result.rows[0]
+        });
+      })
+      .catch((error) => {
+        response.status(500).send({
+          status: 500,
+          error: 'Error fetching the specific user, ensure you provide valid credentials'
+        });
+      });
+  }
+
+  static makeCashier(request, response) {
+    const { email } = request.params;
+    const { type } = request.body;
+
+    const { value, error } = validate.emailParams(request.params);
+    if (error) {
+      return response.status(400).json({
+        status: 400,
+        error: 'Invalid input, ensure input values are/is correct'
+      });
+    }
+
+
+    const makeCashierQuery = `UPDATE users
+      SET "type"='${type}' WHERE "email"='${email}' returning * `;
+    return connectDB.query(makeCashierQuery)
+      .then((result) => {
+        if (result.rowCount === 0) {
+          response.status(400).send({
+            status: 400,
+            error: 'Email does not exist'
+          });
+        }
+        return response.status(200).send({
+          status: 202,
+          message: 'User successfully updated'
+        });
+      })
+      .catch((error) => {
+        response.status(500).send({
+          status: 500,
+          error: 'Error updating the user, ensure you provide valid credentials'
+        });
+      });
+  }
+
+  static makeAdmin(request, response) {
+    const { email } = request.params;
+
+    const { value, error } = validate.emailParams(request.params);
+    if (error) {
+      return response.status(400).json({
+        status: 400,
+        error: 'Invalid input, ensure input values are/is correct'
+      });
+    }
+
+
+    const makeAdminQuery = `UPDATE users
+      SET "isAdmin"='true' WHERE "email"='${email}' returning * `;
+    return connectDB.query(makeAdminQuery)
+      .then((result) => {
+        if (result.rowCount === 0) {
+          response.status(400).send({
+            status: 400,
+            error: 'Email does not exist'
+          });
+        }
+        return response.status(200).send({
+          status: 202,
+          message: 'User successfully updated'
+        });
+      })
+      .catch((error) => {
+        response.status(500).send({
+          status: 500,
+          error: 'Error updating the user, ensure you provide valid credentials'
+        });
       });
   }
 }

--- a/server/v2/routes/accounts.js
+++ b/server/v2/routes/accounts.js
@@ -1,16 +1,23 @@
 import { Router } from 'express';
 import accountController from '../controllers/account';
+
+import BodySchemaValidator from '../../middleware/BodySchemaValidator';
+import ParamsSchemaValidator from '../../middleware/ParamsSchemaValidator';
+
 import auth from '../../middleware/Auth';
 
 const router = Router();
 
+const validateBody = BodySchemaValidator();
+const validateParams = ParamsSchemaValidator();
+
 router.get('/accounts/', auth, accountController.getAllAccounts);
-router.get('/accounts/:accountNumber', auth, accountController.getOne);
+router.get('/accounts/:accountNumber', auth, validateParams, accountController.getOne);
 router.post('/accounts/', auth, accountController.create);
 router.patch('/accounts/:accountNumber', auth, accountController.accountStatusUpdate);
-router.delete('/accounts/:accountNumber', auth, accountController.deleteAccount);
+router.delete('/accounts/:accountNumber', auth, validateParams, accountController.deleteAccount);
 router.get('/accounts/status/dormant', auth, accountController.getAllDormantAccounts);
 router.get('/accounts/status/active', auth, accountController.getAllActiveAccounts);
-router.get('/accounts/user/:email', auth, accountController.getAllAccountsSpecificUser);
+router.get('/accounts/user/:email', auth, validateParams, accountController.getAllAccountsSpecificUser);
 
 export default router;

--- a/server/v2/routes/transactions.js
+++ b/server/v2/routes/transactions.js
@@ -1,14 +1,19 @@
 import { Router } from 'express';
 import transctionController from '../controllers/transaction';
+import BodySchemaValidator from '../../middleware/BodySchemaValidator';
+import ParamsSchemaValidator from '../../middleware/ParamsSchemaValidator';
+
 import auth from '../../middleware/Auth';
 
 const router = Router();
 
+const validateBody = BodySchemaValidator();
+const validateParams = ParamsSchemaValidator();
 
 router.get('/transactions/', auth, transctionController.fetchAll);
-router.get('/transactions/:id', auth, transctionController.fetchSpecificTransaction);
-router.post('/transactions/:accountNumber/credit', auth, transctionController.creditAccount);
-router.post('/transactions/:accountNumber/debit', auth, transctionController.debitAccount);
-router.get('/transactions/:accountNumber/transactions', auth, transctionController.getSpecificAccountTransactions);
+router.get('/transactions/:id', auth, validateParams, transctionController.fetchSpecificTransaction);
+router.post('/transactions/:accountNumber/credit', auth, validateParams, transctionController.creditAccount);
+router.post('/transactions/:accountNumber/debit', auth, validateParams, transctionController.debitAccount);
+router.get('/transactions/:accountNumber/transactions', auth, validateParams, transctionController.getSpecificAccountTransactions);
 
 export default router;

--- a/server/v2/routes/users.js
+++ b/server/v2/routes/users.js
@@ -1,10 +1,19 @@
 import { Router } from 'express';
 import userController from '../controllers/user';
 import validate from '../../middleware/validate';
+import ParamsSchemaValidator from '../../middleware/ParamsSchemaValidator';
+
+import auth from '../../middleware/Auth';
 
 const router = Router();
 
+const validateParams = ParamsSchemaValidator();
+
 router.post('/auth/signup', userController.signup);
 router.post('/auth/signin', userController.signin);
+router.patch('/users/:email/cashier', validateParams, userController.makeCashier);
+router.patch('/users/:email/admin', validateParams, userController.makeAdmin);
+router.get('/users/user/:email', validateParams, userController.getOneUser);
+router.get('/users', validateParams, userController.getAllUsers);
 
 export default router;


### PR DESCRIPTION
### What does this PR do?
- This PR ensures that an admin can update user type from client to cashier or admin

### Description of Task to be completed?
#### Have the following working:
- ensure that admin can update the user type
- ensure that admin can make isAdmin status true
- ensure that user can fetch a list of all registered users
### How should this be manually tested?
#### The following steps can be used:
- Clone the repository, cd into the server folder and run `npm install` on the terminal and start the server with `npm run dev`
- On Postman, make a PATCH HTTP requests to `localhost:3001/api/v2/users/:email/cashier` or `localhost:3001/api/v2/users/:email/cashier` with the desired user type in the request body
- There should be a success message in the event of valid credentials or error if invalid credentials are supplied

### Any background context you want to provide?
- User should ensure there is `node`, `npm` and `postman` installed on their machine.

### What are the relevant pivotal tracker stories?
Chore #165668030: https://www.pivotaltracker.com/story/show/165668030